### PR TITLE
Add rule parser and tests

### DIFF
--- a/rule_parser.py
+++ b/rule_parser.py
@@ -1,0 +1,58 @@
+import re
+from dataclasses import dataclass
+from typing import Callable, List
+
+@dataclass
+class Rule:
+    text: str
+    func: Callable[[List[int], List[int]], bool]
+
+    def evaluate(self, combo: List[int], seed: List[int]) -> bool:
+        return self.func(combo, seed)
+
+def parse_rules(lines: List[str]) -> List[Rule]:
+    """Parse textual rules into executable Rule objects."""
+    rules: List[Rule] = []
+    for line in lines:
+        raw = line.strip().strip('"')
+        if not raw:
+            continue
+        rule = None
+        # Pattern: digit sum equals N
+        m = re.search(r"digit sum of (?:the )?combination equals (\d+)", raw, re.I)
+        if m:
+            target = int(m.group(1))
+            rule = Rule(raw, lambda c, s, t=target: sum(c) == t)
+        # Pattern: seed contains digits -> eliminate even sums
+        if rule is None:
+            m = re.search(r"seed contains.*?([0-9, ]+).*eliminate all even sum", raw, re.I)
+            if m:
+                digits = [int(d) for d in re.findall(r"\d", m.group(1))]
+                rule = Rule(raw, lambda c, s, d=digits: all(x in s for x in d) and sum(c) % 2 == 0)
+        # Pattern: seed includes digits -> eliminate odd sums
+        if rule is None:
+            if "odd-sum" in raw.lower():
+                m = re.search(r"\[(\d+(?:,\d+)*)\]", raw)
+                if m:
+                    digits = [int(d) for d in m.group(1).split(',')]
+                    rule = Rule(
+                        raw,
+                        lambda c, s, d=digits: all(x in s for x in d) and sum(c) % 2 == 1,
+                    )
+        # Pattern: seed sum end digit and combo sum end digit
+        if rule is None:
+            m = re.search(r"seed sum end digit is (\d).*combo sum end digit is (\d)", raw, re.I)
+            if m:
+                sd, cd = int(m.group(1)), int(m.group(2))
+                rule = Rule(raw, lambda c, s, sd=sd, cd=cd: sum(s) % 10 == sd and sum(c) % 10 == cd)
+        # Pattern: combo has >=N shared digits with seed and sum < M
+        if rule is None:
+            m = re.search(r"combo has .*?(\d+) shared digits.*sum < ?(\d+)", raw, re.I)
+            if m:
+                n, mval = int(m.group(1)), int(m.group(2))
+                rule = Rule(raw, lambda c, s, n=n, mval=mval: len(set(c) & set(s)) >= n and sum(c) < mval)
+        # Default rule if no pattern matched
+        if rule is None:
+            rule = Rule(raw, lambda c, s: False)
+        rules.append(rule)
+    return rules

--- a/tests/test_parse_rules.py
+++ b/tests/test_parse_rules.py
@@ -1,0 +1,53 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from rule_parser import parse_rules
+
+
+def load_lines():
+    with open('filter intent summary.txt') as f:
+        return [ln.strip().strip('"') for ln in f if ln.strip()]
+
+
+def test_rule_count():
+    lines = load_lines()
+    rules = parse_rules(lines)
+    assert len(rules) == len(lines)
+
+
+def find_rule(rules, text):
+    for r in rules:
+        if text.lower() in r.text.lower():
+            return r
+    raise AssertionError(f"rule containing '{text}' not found")
+
+
+def test_digit_sum_equals():
+    lines = load_lines()
+    rules = parse_rules(lines)
+    rule = find_rule(rules, 'digit sum of the combination equals 1')
+    assert rule.evaluate([0,0,0,0,1], [1,2,3,4,5])
+    assert not rule.evaluate([0,0,0,0,2], [1,2,3,4,5])
+
+
+def test_seed_contains_even_sum():
+    lines = load_lines()
+    rules = parse_rules(lines)
+    rule = find_rule(rules, '4, 5, 6, 8')
+    assert rule.evaluate([1,1,1,1,2], [4,5,6,8,9])
+    assert not rule.evaluate([1,1,1,1,1], [4,5,6,8,9])
+
+
+def test_seed_includes_odd_sum():
+    lines = load_lines()
+    rules = parse_rules(lines)
+    rule = find_rule(rules, '[1,2,6,8]')
+    assert rule.evaluate([1,1,1,1,1], [1,2,6,8,0])
+    assert not rule.evaluate([1,1,1,1,2], [1,2,6,8,0])
+
+
+def test_sum_end_digits():
+    lines = load_lines()
+    rules = parse_rules(lines)
+    rule = find_rule(rules, 'seed sum end digit is 7 and combo sum end digit is 8')
+    assert rule.evaluate([1,1,1,1,4], [1,2,2,1,1])
+    assert not rule.evaluate([1,1,1,1,4], [2,2,2,2,2])


### PR DESCRIPTION
## Summary
- implement `rule_parser.parse_rules` to handle common patterns from the intent file
- add unit tests covering parsing and rule behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3b6cdca48324bbb1e1589c0b23dc